### PR TITLE
Fix CI workflow: checkout before setup-go for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.23
-        uses: actions/setup-go@v4
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v3
 
       - name: build and test
         run: |
@@ -33,7 +33,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.3.1
+          version: v2.6
           skip-pkg-cache: true
 
       - name: install  goveralls

--- a/stringutils.go
+++ b/stringutils.go
@@ -49,6 +49,7 @@ func DeDup(keys []string) []string {
 }
 
 // DeDupBig remove duplicates from slice.
+//
 // Deprecated: Use DeDup instead. This function now just calls DeDup for backwards compatibility.
 func DeDupBig(keys []string) []string {
 	return DeDup(keys)


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- setup-go needs go.mod/go.sum files to generate cache keys
- Update actions to latest versions (checkout@v4, setup-go@v5)
- Update golangci-lint to v2.6
- Fix deprecation comment formatting